### PR TITLE
修复网络代理问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "musicfree-desktop",
-  "version": "0.0.7-alpha.1",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "musicfree-desktop",
-      "version": "0.0.7-alpha.1",
+      "version": "0.0.7",
       "license": "GPL",
       "dependencies": {
         "@headlessui/react": "^1.7.15",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",
-    "dev": "electron-forge start --inspect-electron",
+    "dev": "chcp 65001 && electron-forge start --inspect-electron",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",

--- a/src/shared/plugin-manager/main/index.ts
+++ b/src/shared/plugin-manager/main/index.ts
@@ -3,8 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 import {Plugin} from "./plugin";
 import {rimraf} from "rimraf";
-import _axios from "axios";
-import https from "https";
+import axios from "axios";
 import voidCallback from "@/common/void-callback";
 import {localPluginHash, localPluginName} from "@/common/constant";
 import localPlugin from "./internal-plugins/local-plugin";
@@ -14,12 +13,6 @@ import AppConfig from "@shared/app-config/main";
 import {compare} from "compare-versions";
 import {nanoid} from "nanoid";
 import logger from "@shared/logger/main";
-
-const axios = _axios.create({
-    httpsAgent: new https.Agent({
-        rejectUnauthorized: false
-    })
-});
 
 interface ICallPluginMethodParams<
     T extends keyof IPlugin.IPluginInstanceMethods


### PR DESCRIPTION
重写handleProxy方法，确保axios库默认走直连
健壮代理模式下的逻辑性
修正plugin-manager里新建agent的行为，让其使用全局设置。
修复electron dev控制台日志中文乱码问题

## PR 解决的问题 (PR Summary)
1. axios库默认遵循HTTP_PROXY 和 HTTPS_PROXY 环境变量，如果用户电脑里有这两个环境变量，会导致axios使用自己的proxy，从而使软件无法访问网络。通过修改handleProxy方法，确保axios库默认走直连，代理模式下使用https-proxy-agent库。
2. 如果直接new URL(host)，会导致host如果是"127.0.0.1"这种非url格式时出现错误，PR进行了条件检查，修复了这个BUG。
3. plugin-manager里的axios没有遵循全局设置，修改代码使其一致。
4. 修复npm run dev时的日志中文乱码问题

## 影响范围 (Impact Scope)
网络代理

## 截屏 (Screenshot)
| 改动前 (Before) | 改动后 (After) |
|     ------     |    ------      |
| 
![image](https://github.com/user-attachments/assets/08fe0085-1a3b-4ae8-8ac9-f3c7169fb7b5)
 | 
![image](https://github.com/user-attachments/assets/6a52aab8-3dcb-44f2-9795-5534c3ad2e7a)
| 
