### PR TITLE
修复代理设置时的host错误，dev时的日志中文乱码

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",
-    "dev": "electron-forge start --inspect-electron",
+    "dev": "chcp 65001 && electron-forge start --inspect-electron",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -261,7 +261,13 @@ function handleProxy(enabled: boolean, host?: string | null, port?: string | nul
             axios.defaults.httpAgent = undefined;
             axios.defaults.httpsAgent = undefined;
         } else if (host) {
-            const proxyUrl = new URL(host);
+            let hostUrl = host;
+            // 使用 startsWith() 方法检查 host 是否包含协议前缀
+            if (!hostUrl.startsWith("http://") && !hostUrl.startsWith("https://")) {
+                // 如果两个都不是，则为其添加默认的 http:// 前缀
+                hostUrl = `http://${host}`;
+            }
+            const proxyUrl = new URL(hostUrl);
             proxyUrl.port = port;
             proxyUrl.username = username;
             proxyUrl.password = password;


### PR DESCRIPTION
## PR 解决的问题 (PR Summary)
1. 如果直接new URL(host)，会导致host如果是"127.0.0.1"这种非url格式时出现错误，PR进行了条件检查，修复了这个BUG。
2. 修复npm run dev时的日志中文乱码问题

## 影响范围 (Impact Scope)
无
