### PR TITLE
feat: Implement lyric offset adjustment

### DIFF
--- a/src/renderer-lrc/pages/index.tsx
+++ b/src/renderer-lrc/pages/index.tsx
@@ -11,10 +11,13 @@ import AppConfig from "@shared/app-config/renderer";
 import messageBus, {useAppStatePartial} from "@shared/message-bus/renderer/extension";
 import {IAppState} from "@shared/message-bus/type";
 
+const LYRIC_OFFSET_STEP = 0.1; // 100ms
+
 export default function LyricWindowPage() {
     const currentMusic = useAppStatePartial("musicItem");
     const playerState = useAppStatePartial("playerState");
     const lockLyric = useAppConfig("lyric.lockLyric");
+    const [lyricOffset, setLyricOffset] = useAppConfig("lyric.offset");
     const [showOperations, setShowOperations] = useState(false);
 
     const mouseOverTimerRef = useRef<number | null>(null);
@@ -106,6 +109,27 @@ export default function LyricWindowPage() {
                             >
                                 <SvgAsset iconName="skip-right"></SvgAsset>
                             </div>
+                            {/* Lyric Offset Adjustment Buttons */}
+                            <div
+                                className="operation-button"
+                                onClick={() => {
+                                    setLyricOffset((lyricOffset ?? 0) - LYRIC_OFFSET_STEP);
+                                }}
+                            >
+                                <SvgAsset iconName="font-size-smaller"></SvgAsset> {/* Placeholder icon */}
+                            </div>
+                            <div className="operation-button-text">
+                                {((lyricOffset ?? 0) * 1000).toFixed(0)}ms
+                            </div>
+                            <div
+                                className="operation-button"
+                                onClick={() => {
+                                    setLyricOffset((lyricOffset ?? 0) + LYRIC_OFFSET_STEP);
+                                }}
+                            >
+                                <SvgAsset iconName="font-size-larger"></SvgAsset> {/* Placeholder icon */}
+                            </div>
+                            {/* End Lyric Offset Adjustment Buttons */}
                             <div
                                 className="operation-button"
                                 onClick={() => {
@@ -139,6 +163,7 @@ function LyricContent() {
     const currentMusic = useAppStatePartial("musicItem");
     const currentLyric = useAppStatePartial("parsedLrc");
     const currentFullLyric = useAppStatePartial("fullLyric");
+    const [lyricOffset] = useAppConfig("lyric.offset"); // Get the offset
 
     const fontDataConfig = useAppConfig("lyric.fontData");
     const fontSizeConfig = useAppConfig("lyric.fontSize");

--- a/src/renderer/core/track-player/index.ts
+++ b/src/renderer/core/track-player/index.ts
@@ -241,6 +241,11 @@ class TrackPlayer {
         this.createAudioController();
         this.setupEvents();
 
+        // Listen for lyric offset changes
+        AppConfig.onDidChange("lyric.offset", () => {
+            this.fetchCurrentLyric(true); // Force reload of lyrics
+        });
+
         // 3. resume state
         musicQueueStore.setValue(playList);
         this.indexMap.update(playList);
@@ -645,9 +650,11 @@ class TrackPlayer {
             if (!lyricSource?.rawLrc && !lyricSource?.translation) {
                 this.setCurrentLyric({});
             }
+            const lyricOffset = AppConfig.getConfig("lyric.offset") ?? 0; // Get lyric offset
             const parser = new LyricParser(lyricSource.rawLrc, {
                 musicItem: currentMusic,
-                translation: lyricSource.translation
+                translation: lyricSource.translation,
+                offset: lyricOffset // Pass offset to parser
             });
 
             this.setCurrentLyric({

--- a/src/renderer/utils/lyric-parser.ts
+++ b/src/renderer/utils/lyric-parser.ts
@@ -6,6 +6,7 @@ type LyricMeta = Record<string, any>;
 interface IOptions {
   musicItem?: IMusic.IMusicItem;
   translation?: string;
+  offset?: number; // Added offset option
 }
 
 export interface IParsedLrcItem {
@@ -21,6 +22,7 @@ export interface IParsedLrcItem {
 
 export default class LyricParser {
   private _musicItem?: IMusic.IMusicItem;
+  private _offset: number; // Added offset property
 
   private meta: LyricMeta;
   private lrcItems: Array<IParsedLrcItem>;
@@ -33,9 +35,14 @@ export default class LyricParser {
     return this._musicItem;
   }
 
+  get offset() {
+    return this._offset;
+  }
+
   constructor(raw: string, options?: IOptions) {
     // init
     this._musicItem = options?.musicItem;
+    this._offset = options?.offset ?? 0; // Initialize offset
     let translation = options?.translation;
     if (!raw && translation) {
       raw = translation;
@@ -74,7 +81,8 @@ export default class LyricParser {
   }
 
   getPosition(position: number): IParsedLrcItem | null {
-    position = position - (this.meta?.offset ?? 0);
+    // Apply the local offset in addition to the metadata offset
+    position = position - (this.meta?.offset ?? 0) - this._offset;
     let index;
     /** 最前面 */
     if (!this.lrcItems[0] || position < this.lrcItems[0].time) {


### PR DESCRIPTION
This commit introduces a feature to allow users to fine-tune lyric synchronization by adjusting an offset.

Changes include:
- Modified LyricParser to accept an offset option.
- Added UI elements (+/- buttons and current offset display) in the lyric window.
- Stored the lyric offset in application configuration for persistence.
- Updated TrackPlayer to use the offset when parsing lyrics and to re-parse on offset changes.

> [!CAUTION] 
> PR 请提交到 `dev` 分支  (Please submit PR to `dev` branch)

## PR 解决的问题 (PR Summary)
> 简单描述一下这个 PR 要解决的问题，如果是 issues 中的问题，请附加 issue 编号  
> (Please provide a brief description of this PR. If it aims to resolve an issue, please include the issue number)

## 影响范围 (Impact Scope)
> 可选填写，说明一下改动的影响范围  
> (Optional, explain the scope of impact of the changes)

## 截屏 (Screenshot)
| 改动前 (Before) | 改动后 (After) |
|     ------     |    ------      |
| 在这里粘贴图片 (Paste screenshot here) | 在这里粘贴图片 (Paste screenshot here) | 
