### PR TITLE
Fix：修复在线歌单的分页加载问题

### DIFF
--- a/src/common/media-util.ts
+++ b/src/common/media-util.ts
@@ -13,7 +13,7 @@ export function isSameMedia(
     b?: IMedia.IMediaBase | null,
 ) {
     if (a && b) {
-        return a.id === b.id && a.platform === b.platform;
+        return a.id == b.id && a.platform == b.platform;
     }
     return false;
 }

--- a/src/renderer/pages/main-page/views/music-sheet-view/remote-sheet/hooks/usePluginSheetMusicList.ts
+++ b/src/renderer/pages/main-page/views/music-sheet-view/remote-sheet/hooks/usePluginSheetMusicList.ts
@@ -21,19 +21,12 @@ export default function usePluginSheetMusicList(
     );
 
     // 当前正在搜索的信息
-    const currentSheetItemRef = useRef<IMusic.IMusicSheetItem | null>({
-        ...originalSheetItem,
-        platform,
-        id,
-    });
+    const currentSheetItemRef = useRef<IMusic.IMusicSheetItem | null>(null);
     // 页码
     const currentPageRef = useRef(1);
 
     const getSheetDetail = async () => {
-        // 用 platform 和 id 判断是否切换了歌单，而不是用 originalSheetItem 的引用
-        const isNewSheet = currentSheetItemRef.current?.platform !== platform || currentSheetItemRef.current?.id !== id;
-
-        if (isNewSheet) {
+        if (!isSameMedia(currentSheetItemRef.current, originalSheetItem)) {
             // 1.1 如果是切换了新的歌单
             // 恢复初始状态 并设置当前的歌曲项
             currentSheetItemRef.current = {


### PR DESCRIPTION
> [!CAUTION] 
> PR 请提交到 `dev` 分支  (Please submit PR to `dev` branch)

## PR 解决的问题 (PR Summary)
> issue 编号：https://github.com/maotoumao/MusicFreeDesktop/issues/313
问题描述
在线歌单（如"热门歌单"）加载到第40首歌曲时，页面会刷新重置，导致无法继续加载更多歌曲。而收藏歌单（本地歌单）可以正常加载到67首以上。

根本原因
usePluginSheetMusicList hook 中用 isSameMedia(currentSheetItemRef.current, originalSheetItem) 判断是否切换了歌单。但 originalSheetItem 来自 history.state?.usr?.sheetItem，每次组件重新渲染时都是新的对象引用。这导致即使是同一个歌单，每次调用 getSheetDetail() 时都被误判为"切换了新歌单"，从而触发重置逻辑：

清空 musicList
重置 currentPageRef 为 1
重新从第1页开始加载
当用户滚动到第40首歌曲触发加载更多时，本应加载第2页，但由于这个 bug，反而重新加载第1页，导致列表被清空，页面重新渲染。

解决方案
改用 platform 和 id 来判断是否切换了歌单，而不是依赖 originalSheetItem 的对象引用。这两个值是稳定的，只有真正切换到不同的歌单时才会改变。

## 影响范围 (Impact Scope)
> 修复在线歌单的分页加载问题
不影响收藏歌单的功能
不影响其他歌单相关功能

## 截屏 (Screenshot)
| 改动前 (Before) | 改动后 (After) |
|     ------     |    ------      |

| <img width="777" height="362" alt="image" src="https://github.com/user-attachments/assets/1a32aed4-6196-4759-a2eb-a2ed3c3af5e7" /> | <img width="1171" height="363" alt="image" src="https://github.com/user-attachments/assets/da6eed22-9641-4b8b-845c-0a0380a409ae" />| 
