### PR TITLE
fix: 修复歌词解析时的空值处理

### DIFF
--- a/src/renderer/core/track-player/index.ts
+++ b/src/renderer/core/track-player/index.ts
@@ -647,10 +647,11 @@ class TrackPlayer {
 
             if (!lyricSource?.rawLrc && !lyricSource?.translation) {
                 this.setCurrentLyric({});
+                return;
             }
-            const parser = new LyricParser(lyricSource.rawLrc, {
+            const parser = new LyricParser(lyricSource?.rawLrc ?? "", {
                 musicItem: currentMusic,
-                translation: lyricSource.translation,
+                translation: lyricSource?.translation,
             });
 
             this.setCurrentLyric({


### PR DESCRIPTION
> [!CAUTION] 
> PR 请提交到 `dev` 分支  (Please submit PR to `dev` branch)

## PR 解决的问题 (PR Summary)
> 修复歌词NPE
<img width="928" height="292" alt="image" src="https://github.com/user-attachments/assets/7b091bbf-3411-48ef-be3f-6e3556e34f69" />


## 截屏 (Screenshot)
<img width="1119" height="194" alt="image" src="https://github.com/user-attachments/assets/7b656f52-6eda-42f2-80da-ccb96ec15553" />
