### PR TITLE
fix: safely restore imported download metadata

### DIFF
--- a/src/infra/downloadManager/renderer.ts
+++ b/src/infra/downloadManager/renderer.ts
@@ -12,6 +12,7 @@ import { useSyncExternalStore, useCallback } from 'react';
 import EventEmitter from 'eventemitter3';
 import { compositeKey } from '@common/mediaKey';
 import debounce from '@common/debounce';
+import mediaMeta from '@infra/mediaMeta/renderer';
 import { CONTEXT_BRIDGE_KEY } from './common/constant';
 import type {
     IDownloadTask,
@@ -103,6 +104,7 @@ class DownloadManagerRenderer {
     /** IPC 事件取消订阅函数 */
     private unsubProgress: (() => void) | null = null;
     private unsubTaskEvent: (() => void) | null = null;
+    private unsubMetaChanged: (() => void) | null = null;
 
     /** 防抖刷新任务列表（批量下载时避免高频 IPC） */
     private debouncedRefresh = debounce(async () => {
@@ -197,6 +199,29 @@ class DownloadManagerRenderer {
             this.debouncedRefresh();
         });
 
+        // 监听 mediaMeta 变更，当 downloadData 被写入（如导入歌单时）实时更新 downloadedMap
+        this.unsubMetaChanged = mediaMeta.onMetaChanged((event) => {
+            const { platform, musicId, meta } = event;
+            const key = compositeKey(platform, musicId);
+            if (meta?.downloadData) {
+                const prev = this.downloadedMap.get(key);
+                if (
+                    !prev ||
+                    prev.path !== meta.downloadData.path ||
+                    prev.quality !== meta.downloadData.quality
+                ) {
+                    this.downloadedMap.set(key, {
+                        path: meta.downloadData.path,
+                        quality: meta.downloadData.quality,
+                    });
+                    this.events.emit('downloadChange');
+                }
+            } else if (meta && !meta.downloadData && this.downloadedMap.has(key)) {
+                this.downloadedMap.delete(key);
+                this.events.emit('downloadChange');
+            }
+        });
+
         this.isSetup = true;
     }
 
@@ -268,6 +293,8 @@ class DownloadManagerRenderer {
         this.unsubProgress = null;
         this.unsubTaskEvent?.();
         this.unsubTaskEvent = null;
+        this.unsubMetaChanged?.();
+        this.unsubMetaChanged = null;
         this.events.removeAllListeners();
         this.activeTaskMap.clear();
         this.downloadedMap.clear();

--- a/src/infra/musicSheet/main/index.ts
+++ b/src/infra/musicSheet/main/index.ts
@@ -7,6 +7,7 @@
  * - 导出歌单详情
  * - IPC 注册 + 事件广播
  */
+import fs from 'fs';
 import { ipcMain } from 'electron';
 import { nanoid } from 'nanoid';
 import i18n from '@infra/i18n/main';
@@ -32,6 +33,7 @@ import { createQueries, type IMusicSheetQueries } from './queries';
 import { INTERNAL_SLIM_KEY } from '@common/constant';
 import { safeStringify, safeParse } from '@common/safeSerialize';
 import type { IBackupProvider, IBackupSheet, RestoreMode } from '@appTypes/infra/backup';
+import type { IMediaMetaProvider } from '@appTypes/infra/mediaMeta';
 
 class MusicSheetManager {
     private isSetup = false;
@@ -73,30 +75,7 @@ class MusicSheetManager {
      * 主进程内部调用，不通过 IPC。
      */
     public addMusicToSheet(musicItem: IMusic.IMusicItem | IMusicItemSlim, sheetId: string): void {
-        const db = this.db.getDatabase();
-        db.transaction(() => {
-            const minOrder = (this.queries.getMinSortOrder.get(sheetId) as any).minOrder;
-            const sid = String(musicItem.id);
-            const now = Date.now();
-
-            this.queries.upsertMusicItem.run({
-                platform: musicItem.platform,
-                id: sid,
-                title: musicItem.title,
-                artist: musicItem.artist ?? '',
-                album: musicItem.album ?? '',
-                duration: musicItem.duration ?? null,
-                artwork: musicItem.artwork ?? null,
-                raw: (musicItem as any)[INTERNAL_SLIM_KEY] ? null : safeStringify(musicItem),
-            });
-            this.queries.insertRelation.run({
-                sheetId,
-                platform: musicItem.platform,
-                musicId: sid,
-                sortOrder: minOrder - 1,
-                addedAt: now,
-            });
-        })();
+        this.addMusicToSheetSilently(musicItem, sheetId);
         this.broadcastMusicSheetEvent({ origin: 'internal', sheetId });
     }
 
@@ -147,8 +126,10 @@ class MusicSheetManager {
     /**
      * 返回 backup 模块所需的 DI 适配器。
      * 封装了歌单导出和导入操作，主进程内直接调用，不经 IPC。
+     *
+     * @param deps.mediaMeta - 用于将导入歌曲的 $.downloadData 写入 media_meta 表
      */
-    public getBackupProvider(): IBackupProvider {
+    public getBackupProvider(deps?: { mediaMeta?: IMediaMetaProvider }): IBackupProvider {
         return {
             /** 获取所有可导出歌单的元数据（排除 system 类型） */
             getExportableSheets: (): Array<{ id: string; title: string }> => {
@@ -177,6 +158,15 @@ class MusicSheetManager {
             ): { sheetsCount: number; songsCount: number } => {
                 const db = this.db.getDatabase();
                 let totalSongs = 0;
+
+                // 收集含 downloadData 的歌曲（Map 去重，同一首歌可能在多个歌单中出现）
+                const downloadItems = new Map<
+                    string,
+                    {
+                        item: IMusic.IMusicItem;
+                        downloadData: { path: string; quality: IMusic.IQualityKey };
+                    }
+                >();
 
                 // overwrite 清理在单独事务中执行
                 if (mode === 'overwrite') {
@@ -239,9 +229,44 @@ class MusicSheetManager {
                                 sortOrder: ++maxOrder,
                                 addedAt: now,
                             });
+
+                            // 收集含 $.downloadData 的歌曲
+                            const internalData = (item as any).$;
+                            if (
+                                internalData?.downloadData?.path &&
+                                internalData?.downloadData?.quality
+                            ) {
+                                const key = `${item.platform}@@${sid}`;
+                                if (!downloadItems.has(key)) {
+                                    downloadItems.set(key, {
+                                        item,
+                                        downloadData: internalData.downloadData,
+                                    });
+                                }
+                            }
                         }
                         totalSongs += sheet.musicList.length;
                     })();
+                }
+
+                // 将含下载数据且本地路径有效的歌曲写入 media_meta 并加入 __downloaded__ 歌单
+                if (downloadItems.size > 0 && deps?.mediaMeta) {
+                    for (const [, { item, downloadData }] of downloadItems) {
+                        const existingDownload = deps.mediaMeta.getDownloadData(
+                            item.platform,
+                            String(item.id),
+                        );
+                        if (existingDownload && fs.existsSync(existingDownload.path)) {
+                            continue;
+                        }
+                        if (!fs.existsSync(downloadData.path)) {
+                            continue;
+                        }
+                        deps.mediaMeta.setMeta(item.platform, String(item.id), {
+                            downloadData,
+                        });
+                        this.addMusicToSheetSilently(item, DOWNLOADED_SHEET_ID);
+                    }
                 }
 
                 this.scheduleOrphanCleanup();
@@ -250,6 +275,36 @@ class MusicSheetManager {
                 return { sheetsCount: sheets.length, songsCount: totalSongs };
             },
         };
+    }
+
+    private addMusicToSheetSilently(
+        musicItem: IMusic.IMusicItem | IMusicItemSlim,
+        sheetId: string,
+    ): void {
+        const db = this.db.getDatabase();
+        db.transaction(() => {
+            const minOrder = (this.queries.getMinSortOrder.get(sheetId) as any).minOrder;
+            const sid = String(musicItem.id);
+            const now = Date.now();
+
+            this.queries.upsertMusicItem.run({
+                platform: musicItem.platform,
+                id: sid,
+                title: musicItem.title,
+                artist: musicItem.artist ?? '',
+                album: musicItem.album ?? '',
+                duration: musicItem.duration ?? null,
+                artwork: musicItem.artwork ?? null,
+                raw: (musicItem as any)[INTERNAL_SLIM_KEY] ? null : safeStringify(musicItem),
+            });
+            this.queries.insertRelation.run({
+                sheetId,
+                platform: musicItem.platform,
+                musicId: sid,
+                sortOrder: minOrder - 1,
+                addedAt: now,
+            });
+        })();
     }
 
     private registerIpcHandlers() {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -143,7 +143,9 @@ async function bootstrapInfra(windowManager: IWindowManager) {
     backup.setup({
         windowManager,
         appConfig,
-        backupProvider: musicSheet.getBackupProvider(),
+        backupProvider: musicSheet.getBackupProvider({
+            mediaMeta: mediaMetaProvider,
+        }),
     });
 
     // 注册内建插件


### PR DESCRIPTION
> [!CAUTION]
> PR 请提交到 `dev` 分支  (Please submit PR to `dev` branch)

## PR 解决的问题 (PR Summary)
修复导入歌单备份时，歌曲 `$.downloadData` 未正确恢复到 `media_meta`，导致本地已下载歌曲在导入后仍被当作未下载、播放时不会优先走本地文件的问题。

同时补上两个边界问题：
1. 仅在导入的 `downloadData.path` 本地实际存在时才恢复下载状态，避免用失效绝对路径覆盖当前机器上的有效下载信息。
2. 导入时将 `__downloaded__` 歌单写入改为静默更新，避免每首歌都触发一次内部歌单广播，减少大量无意义的 renderer 刷新。

## 影响范围 (Impact Scope)
- 歌单备份导入/恢复流程
- `media_meta` 下载信息恢复逻辑
- 已下载歌曲状态同步
- `__downloaded__` 系统歌单更新逻辑
- renderer 侧下载状态实时刷新

## 截屏 (Screenshot)
| 改动前 (Before) | 改动后 (After) |
|     ------     |    ------      |
| / | / |
