### PR TITLE
fix: restore legacy download metadata during migration

### DIFF
--- a/src/renderer/mainWindow/core/legacyMigration.ts
+++ b/src/renderer/mainWindow/core/legacyMigration.ts
@@ -16,6 +16,7 @@
 import { syncKV, asyncKV } from '@renderer/common/kvStore';
 import { showModal } from '@renderer/mainWindow/components/ui/Modal/modalManager';
 import type { IBackupData, IBackupSheet } from '@appTypes/infra/backup';
+import { DOWNLOADED_SHEET_ID } from '@infra/musicSheet/common/constant';
 
 // ─── 常量 ───
 
@@ -243,6 +244,20 @@ function sanitizeMusicItem(raw: any): IMusic.IMusicItem | null {
     return item as IMusic.IMusicItem;
 }
 
+function getLegacyDownloadData(item: IMusic.IMusicItem): {
+    path: string;
+    quality: IMusic.IQualityKey;
+} | null {
+    const downloadData = (item as any).$?.downloadData;
+    if (!downloadData?.path || !downloadData?.quality) {
+        return null;
+    }
+    return {
+        path: downloadData.path,
+        quality: downloadData.quality,
+    };
+}
+
 // ─── 执行迁移 ───
 
 /**
@@ -257,6 +272,7 @@ function sanitizeMusicItem(raw: any): IMusic.IMusicItem | null {
 export async function executeMigration(): Promise<MigrationResult> {
     // 延迟导入避免循环依赖
     const { default: backup } = await import('@infra/backup/renderer');
+    const { default: mediaMeta } = await import('@infra/mediaMeta/renderer');
     const { default: musicSheet, playQueueBridge } = await import('@infra/musicSheet/renderer');
     const { default: fsUtil } = await import('@infra/fsUtil/renderer');
 
@@ -297,6 +313,13 @@ export async function executeMigration(): Promise<MigrationResult> {
 
         // 组装 IBackupSheet[]
         const backupSheets: IBackupSheet[] = [];
+        const downloadedItems = new Map<
+            string,
+            {
+                item: IMusic.IMusicItem;
+                downloadData: { path: string; quality: IMusic.IQualityKey };
+            }
+        >();
         let totalSongs = 0;
 
         for (const sheet of sheets) {
@@ -306,6 +329,14 @@ export async function executeMigration(): Promise<MigrationResult> {
                 const item = musicPool.get(`${ref.platform}@${ref.id}`);
                 if (item) {
                     musicList.push(item);
+
+                    const downloadData = getLegacyDownloadData(item);
+                    if (downloadData) {
+                        downloadedItems.set(`${item.platform}@${item.id}`, {
+                            item,
+                            downloadData,
+                        });
+                    }
                 }
             }
 
@@ -335,6 +366,19 @@ export async function executeMigration(): Promise<MigrationResult> {
                     encoding: 'utf-8',
                 });
                 await backup.restoreFromFile(tempPath, 'append');
+
+                if (downloadedItems.size > 0) {
+                    for (const [, { item, downloadData }] of downloadedItems) {
+                        await mediaMeta.setMeta(item.platform, String(item.id), {
+                            downloadData,
+                        });
+                    }
+
+                    musicSheet.addMusicToSheet(
+                        Array.from(downloadedItems.values(), ({ item }) => item),
+                        DOWNLOADED_SHEET_ID,
+                    );
+                }
             } finally {
                 // 无论成功失败均删除临时文件
                 try {


### PR DESCRIPTION
> [!CAUTION]
> PR 请提交到 dev 分支 (Please submit PR to dev branch)
> 提到其他分支将会直接关闭 PR

## PR 解决的问题 (PR Summary)

旧版数据迁移流程虽然能够恢复歌单和歌曲数据，但没有把已下载歌曲对应的下载元数据一并迁移，导致升级后这部分歌曲会丢失本地下载状态。

这个 PR 在执行旧版 IndexedDB 数据迁移时，额外恢复已下载歌曲的 downloadData 信息，并将这些歌曲重新加入“已下载”歌单，确保迁移完成后仍能正确识别本地下载文件路径和音质信息。

## 影响范围 (Impact Scope)

影响旧版本用户升级到当前版本时的数据迁移流程，主要包括：

1. 从旧版歌曲记录中提取已下载歌曲的下载信息。
2. 将下载信息写回新的 mediaMeta 存储。
3. 将对应歌曲补入“已下载”歌单。

不影响新安装用户，也不影响已经完成迁移的用户日常使用流程。
