### PR TITLE
为已下载歌曲的右键菜单增加修改曲名功能

### DIFF
--- a/res/lang/en-US.json
+++ b/res/lang/en-US.json
@@ -141,7 +141,9 @@
     "reveal_local_music_in_file_explorer_fail": "Open Failed: ",
 
     "delete_local_downloaded_songs_success": "Deleted {{musicNums}} local songs",
-    "delete_local_downloaded_song_success": "Deleted local song [{{songName}}]"
+    "delete_local_downloaded_song_success": "Deleted local song [{{songName}}]",
+    "rename_music": "Rename Title",
+    "rename_music_success": "Title renamed successfully"
   },
 
   "search_result_page": {

--- a/res/lang/zh-CN.json
+++ b/res/lang/zh-CN.json
@@ -125,7 +125,9 @@
     "reveal_local_music_in_file_explorer": "打开歌曲所在文件夹",
     "reveal_local_music_in_file_explorer_fail": "打开失败: ",
     "delete_local_downloaded_songs_success": "已删除 {{musicNums}} 首本地歌曲",
-    "delete_local_downloaded_song_success": "已删除本地歌曲 [{{songName}}]"
+    "delete_local_downloaded_song_success": "已删除本地歌曲 [{{songName}}]",
+    "rename_music": "修改曲名",
+    "rename_music_success": "曲名修改成功"
   },
   "search_result_page": {
     "search_result_title": "的搜索结果"

--- a/res/lang/zh-TW.json
+++ b/res/lang/zh-TW.json
@@ -141,7 +141,9 @@
     "reveal_local_music_in_file_explorer_fail": "打開失敗：",
 
     "delete_local_downloaded_songs_success": "已刪除 {{musicNums}} 首本地歌曲",
-    "delete_local_downloaded_song_success": "已刪除本地歌曲 [{{songName}}]"
+    "delete_local_downloaded_song_success": "已刪除本地歌曲 [{{songName}}]",
+    "rename_music": "修改曲名",
+    "rename_music_success": "曲名修改成功"
   },
 
   "search_result_page": {

--- a/src/renderer/components/MusicList/index.tsx
+++ b/src/renderer/components/MusicList/index.tsx
@@ -22,7 +22,7 @@ import BottomLoadingState from "../BottomLoadingState";
 import { IContextMenuItem, showContextMenu } from "../ContextMenu";
 import { getInternalData, getMediaPrimaryKey, isSameMedia } from "@/common/media-util";
 import { CSSProperties, memo, useCallback, useEffect, useRef, useState } from "react";
-import { showModal } from "../Modal";
+import { showModal, hideModal } from "../Modal";
 import useVirtualList from "@/hooks/useVirtualList";
 import hotkeys from "hotkeys-js";
 import Downloader from "@/renderer/core/downloader";
@@ -222,6 +222,27 @@ export function showMusicContextMenu(
                 : !isLocalMusic(musicItems) && !Downloader.isDownloaded(musicItems),
             onClick() {
                 Downloader.startDownload(musicItems);
+            },
+        },
+        {
+            title: i18n.t("music_list_context_menu.rename_music"),
+            icon: "pencil",
+            show:
+                !isArray && Downloader.isDownloaded(musicItems),
+            onClick() {
+                showModal("SimpleInputWithState", {
+                    title: i18n.t("music_list_context_menu.rename_music"),
+                    defaultValue: (musicItems as IMusic.IMusicItem).title,
+                    placeholder: i18n.t("media.media_title"),
+                    maxLength: 200,
+                    onOk: async (newTitle: string) => {
+                        const musicItem = musicItems as IMusic.IMusicItem;
+                        const updatedItem = { ...musicItem, title: newTitle };
+                        await musicSheetDB.musicStore.put(updatedItem);
+                        toast.success(i18n.t("music_list_context_menu.rename_music_success"));
+                        hideModal();
+                    },
+                });
             },
         },
         {


### PR DESCRIPTION
## PR 解决的问题 (PR Summary)
为已下载歌曲的右键菜单增加修改曲名功能。用户右键单击任意视图中的已下载单曲，可通过弹窗修改歌曲标题，更新 IndexedDB 中的 title 字段。
- 仅单曲 + 已下载状态时显示该菜单项
- 复用项目已有的 `SimpleInputWithState` 弹窗组件
- 修改 title 后自动刷新列表，并 toast 提示成功
- 不修改磁盘上的文件名

## 影响范围 (Impact Scope)
   | 文件 | 改动 |                                                               
   |---|---|                                                                     
   | `src/renderer/components/MusicList/index.tsx` | 导入 `hideModal`，新增 `rename_music` 右键菜单项 |
   | `res/lang/zh-CN.json` | 新增 `rename_music`、`rename_music_success` 翻译键 |
   | `res/lang/en-US.json` | 新增 `rename_music`、`rename_music_success` 翻译键 |
   | `res/lang/zh-TW.json` | 新增 `rename_music`、`rename_music_success` 翻译键 |
