### PR TITLE
fix: 修复 AxiosHeaderValue 类型不匹配导致的 TypeScript 编译错误

### DIFF
--- a/src/infra/downloadManager/main/downloadTask.ts
+++ b/src/infra/downloadManager/main/downloadTask.ts
@@ -90,7 +90,7 @@ export class DownloadTask {
             });
 
             // 4. 解析总大小
-            const contentLength = parseInt(response.headers['content-length'] ?? '0', 10);
+            const contentLength = parseInt(String(response.headers['content-length'] ?? '0'), 10);
             const isPartial = response.status === 206;
 
             if (isPartial) {
@@ -137,7 +137,7 @@ export class DownloadTask {
             });
 
             // 7. 推断文件扩展名（从 Content-Type，兜底 .mp3）
-            const contentType = response.headers['content-type'] ?? '';
+            const contentType = String(response.headers['content-type'] ?? '');
             const finalPath = await this.resolveFinalPath(contentType);
 
             // 8. 下载完成 → rename 临时文件


### PR DESCRIPTION
## PR 解决的问题

使用 `String()` 包裹 `response.headers['content-length']` 和 `response.headers['content-type']`，兼容新版 axios 中 AxiosHeaderValue 类型（`string | number | boolean | null`）的变化。

## 影响范围

仅 `src/infra/downloadManager/main/downloadTask.ts`，下载功能模块的两处类型适配，无运行时行为变更。

## 截屏

| 改动前 (Before) | 改动后 (After) |
|     ------     |    ------      |
| 编译时两处 TS 报错 | 编译通过，无报错 |