### PR TITLE
fix: 修复右键菜单重复出现「删除本地文件」的问题

### DIFF
--- a/src/renderer/mainWindow/components/business/contextMenus/MusicItemMenu.tsx
+++ b/src/renderer/mainWindow/components/business/contextMenus/MusicItemMenu.tsx
@@ -232,8 +232,9 @@ export function MusicItemMenu(ctx: MusicItemMenuContext): ContextMenuEntry[] {
             });
         }
 
-        if (downloaded) {
+        if (downloaded && singleItem.platform !== LOCAL_PLUGIN_NAME) {
             // 删除已下载的本地文件（同时删除下载记录）
+            // 排除纯本地歌曲（allLocal 路径已提供更完整的删除：删文件 + 从歌单移除 + 从队列移除）
             entries.push({
                 id: 'delete-local-file',
                 icon: <Trash2 />,


### PR DESCRIPTION
## 问题

在歌曲右键菜单中，当一首歌同时满足以下两个条件时，会出现两个「删除本地文件」菜单项：

1. 歌曲被 `downloadManager.isDownloaded()` 标记为已下载
2. 歌曲的 `platform === LOCAL_PLUGIN_NAME`（纯本地歌曲）

### 根因

`MusicItemMenu.tsx` 中有两个独立的删除逻辑分支：

- **`downloaded` 路径（第 237 行）**：删除已下载的本地文件，条件是歌曲已下载
- **`allLocal` 路径（第 279 行）**：删除纯本地文件（移至回收站 + 从所有歌单移除 + 从播放队列移除），条件是选中项全是本地歌曲

当一首歌同时满足两者时，两个分支都添加了删除项，导致重复。

## 修复

在 `downloaded` 路径增加 `singleItem.platform !== LOCAL_PLUGIN_NAME` 排除条件，本地歌曲的删除由 `allLocal` 路径统一处理（它的逻辑更完整）。

## 相关

- 这是已有 bug，并非本次新引入

### 相关截图
<img width="1730" height="974" alt="PixPin_2026-06-03_20-25-29" src="https://github.com/user-attachments/assets/31335b28-2c52-4c3b-86a0-9c64e7ac7bfe" />
