### PR TITLE
feat(sidebar): support collapsible playlist groups

### DIFF
--- a/src/renderer/pages/main-page/components/SideBar/widgets/ListItem/index.tsx
+++ b/src/renderer/pages/main-page/components/SideBar/widgets/ListItem/index.tsx
@@ -1,4 +1,5 @@
 import SvgAsset, { SvgAssetIconNames } from "@/renderer/components/SvgAsset";
+import classNames from "@/renderer/utils/classnames";
 import "./index.scss";
 
 interface IProps {
@@ -7,17 +8,21 @@ interface IProps {
     onContextMenu?: (...args: any) => void;
     iconName?: SvgAssetIconNames;
     title?: string;
+    className?: string;
 }
 
 export default function ListItem(props: IProps) {
-    const { selected, onClick, iconName, title, onContextMenu } = props ?? {};
+    const { selected, onClick, iconName, title, onContextMenu, className } = props ?? {};
     return (
         <div
             onClick={onClick}
             onContextMenu={onContextMenu}
             title={title}
             role="button"
-            className="side-bar--list-item-container"
+            className={classNames([
+                "side-bar--list-item-container",
+                className ?? "",
+            ])}
             data-selected={selected}
         >
             {iconName ? <SvgAsset iconName={iconName}></SvgAsset> : null}

--- a/src/renderer/pages/main-page/components/SideBar/widgets/MySheets/index.scss
+++ b/src/renderer/pages/main-page/components/SideBar/widgets/MySheets/index.scss
@@ -52,4 +52,49 @@
       }
     }
   }
+
+  & .sheet-group-title {
+    height: 3rem;
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    padding-left: 1rem;
+    color: var(--textColor);
+    cursor: pointer;
+    user-select: none;
+    transition: all linear 100ms;
+
+    & svg {
+      width: 1.2rem;
+      height: 1.2rem;
+      margin-right: 0.5rem;
+      flex-shrink: 0;
+      transition: transform linear 100ms;
+    }
+
+    & span {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding-right: 0.5rem;
+    }
+
+    &:hover {
+      background: var(--listHoverColor);
+    }
+
+    &[data-selected="true"] {
+      color: var(--primaryColor);
+    }
+
+    &[data-headlessui-state="open"] {
+      & svg {
+        transform: rotate(90deg);
+      }
+    }
+  }
+
+  & .side-bar--list-item-container.grouped-sheet {
+    padding-left: 2.7rem;
+  }
 }

--- a/src/renderer/pages/main-page/components/SideBar/widgets/MySheets/index.tsx
+++ b/src/renderer/pages/main-page/components/SideBar/widgets/MySheets/index.tsx
@@ -9,7 +9,24 @@ import { localPluginName } from "@/common/constant";
 import { showContextMenu } from "@/renderer/components/ContextMenu";
 import { useTranslation } from "react-i18next";
 import { useSupportedPlugin } from "@shared/plugin-manager/renderer";
+import { useMemo } from "react";
 
+type SheetListEntry =
+    | {
+        type: "sheet";
+        sheet: IMusic.IDBMusicSheetItem;
+        title: string;
+    }
+    | {
+        type: "group";
+        title: string;
+        sheets: Array<{
+            sheet: IMusic.IDBMusicSheetItem;
+            title: string;
+        }>;
+    };
+
+const groupTitleRegExp = /^(.+?)\s+-\s+(.+)$/;
 
 export default function MySheets() {
     const sheetIdMatch = useMatch(
@@ -21,6 +38,137 @@ export default function MySheets() {
     const { t } = useTranslation();
 
     const importablePlugins = useSupportedPlugin("importMusicSheet");
+
+    const groupedMusicSheets = useMemo<SheetListEntry[]>(() => {
+        const prefixCount = new Map<string, number>();
+
+        musicSheets.forEach((item) => {
+            if (item.id === defaultSheet.id) {
+                return;
+            }
+            const prefix = item.title.match(groupTitleRegExp)?.[1]?.trim();
+            if (!prefix) {
+                return;
+            }
+            prefixCount.set(prefix, (prefixCount.get(prefix) ?? 0) + 1);
+        });
+
+        const result: SheetListEntry[] = [];
+        const insertedGroups = new Set<string>();
+
+        musicSheets.forEach((item) => {
+            const matchedTitle = item.title.match(groupTitleRegExp);
+            const prefix = matchedTitle?.[1]?.trim();
+            const childTitle = matchedTitle?.[2]?.trim();
+
+            if (
+                item.id !== defaultSheet.id
+                && prefix
+                && childTitle
+                && (prefixCount.get(prefix) ?? 0) > 1
+            ) {
+                if (!insertedGroups.has(prefix)) {
+                    result.push({
+                        type: "group",
+                        title: prefix,
+                        sheets: musicSheets
+                            .filter((sheet) => {
+                                const titleMatch = sheet.title.match(groupTitleRegExp);
+                                return titleMatch?.[1]?.trim() === prefix;
+                            })
+                            .map((sheet) => ({
+                                sheet,
+                                title: sheet.title.match(groupTitleRegExp)?.[2]?.trim() || sheet.title,
+                            })),
+                    });
+                    insertedGroups.add(prefix);
+                }
+                return;
+            }
+
+            result.push({
+                type: "sheet",
+                sheet: item,
+                title: item.id === defaultSheet.id
+                    ? t("media.default_favorite_sheet_name")
+                    : item.title,
+            });
+        });
+
+        return result;
+    }, [musicSheets, t]);
+
+    function renderSheetItem(
+        item: IMusic.IDBMusicSheetItem,
+        title: string,
+        isGrouped = false,
+    ) {
+        return (
+            <ListItem
+                key={item.id}
+                className={isGrouped ? "grouped-sheet" : undefined}
+                iconName={
+                    item.id === defaultSheet.id ? "heart-outline" : "musical-note"
+                }
+                onClick={() => {
+                    if (currentSheetId !== item.id) {
+                        navigate(`/main/musicsheet/${encodeURIComponent(localPluginName)}/${encodeURIComponent(item.id)}`);
+                    }
+                }}
+                onContextMenu={(e) => {
+                    if (item.id === defaultSheet.id) {
+                        return;
+                    }
+                    showContextMenu({
+                        x: e.clientX,
+                        y: e.clientY,
+                        menuItems: [
+                            {
+                                title: t("side_bar.rename_sheet"),
+                                icon: "pencil-square",
+                                show: item.id !== defaultSheet.id,
+                                onClick() {
+                                    showModal("SimpleInputWithState", {
+                                        placeholder: t(
+                                            "modal.create_local_sheet_placeholder",
+                                        ),
+                                        maxLength: 30,
+                                        title: t("side_bar.rename_sheet"),
+                                        defaultValue: item.title,
+                                        async onOk(text) {
+                                            await MusicSheet.frontend.updateSheet(item.id, {
+                                                title: text,
+                                            });
+                                            hideModal();
+                                        },
+                                    });
+                                },
+                            },
+                            {
+                                title: t("side_bar.delete_sheet"),
+                                icon: "trash",
+                                show: item.id !== defaultSheet.id,
+                                onClick() {
+                                    MusicSheet.frontend.removeSheet(item.id).then(() => {
+                                        if (currentSheetId === item.id) {
+                                            navigate(
+                                                `/main/musicsheet/${encodeURIComponent(localPluginName)}/${defaultSheet.id}`,
+                                                {
+                                                    replace: true,
+                                                },
+                                            );
+                                        }
+                                    });
+                                },
+                            },
+                        ],
+                    });
+                }}
+                selected={currentSheetId === item.id}
+                title={title}
+            ></ListItem>
+        );
+    }
 
     return (
         <div className="side-bar-container--my-sheets">
@@ -54,74 +202,32 @@ export default function MySheets() {
                     </div>
                 </Disclosure.Button>
                 <Disclosure.Panel>
-                    {musicSheets.map((item) => (
-                        <ListItem
-                            key={item.id}
-                            iconName={
-                                item.id === defaultSheet.id ? "heart-outline" : "musical-note"
-                            }
-                            onClick={() => {
-                                if (currentSheetId !== item.id) {
-                                    navigate(`/main/musicsheet/${encodeURIComponent(localPluginName)}/${encodeURIComponent(item.id)}`);
-                                }
-                            }}
-                            onContextMenu={(e) => {
-                                if (item.id === defaultSheet.id) {
-                                    return;
-                                }
-                                showContextMenu({
-                                    x: e.clientX,
-                                    y: e.clientY,
-                                    menuItems: [
-                                        {
-                                            title: t("side_bar.rename_sheet"),
-                                            icon: "pencil-square",
-                                            show: item.id !== defaultSheet.id,
-                                            onClick() {
-                                                showModal("SimpleInputWithState", {
-                                                    placeholder: t(
-                                                        "modal.create_local_sheet_placeholder",
-                                                    ),
-                                                    maxLength: 30,
-                                                    title: t("side_bar.rename_sheet"),
-                                                    defaultValue: item.title,
-                                                    async onOk(text) {
-                                                        await MusicSheet.frontend.updateSheet(item.id, {
-                                                            title: text,
-                                                        });
-                                                        hideModal();
-                                                    },
-                                                });
-                                            },
-                                        },
-                                        {
-                                            title: t("side_bar.delete_sheet"),
-                                            icon: "trash",
-                                            show: item.id !== defaultSheet.id,
-                                            onClick() {
-                                                MusicSheet.frontend.removeSheet(item.id).then(() => {
-                                                    if (currentSheetId === item.id) {
-                                                        navigate(
-                                                            `/main/musicsheet/${encodeURIComponent(localPluginName)}/${defaultSheet.id}`,
-                                                            {
-                                                                replace: true,
-                                                            },
-                                                        );
-                                                    }
-                                                });
-                                            },
-                                        },
-                                    ],
-                                });
-                            }}
-                            selected={currentSheetId === item.id}
-                            title={
-                                item.id === defaultSheet.id
-                                    ? t("media.default_favorite_sheet_name")
-                                    : item.title
-                            }
-                        ></ListItem>
-                    ))}
+                    {groupedMusicSheets.map((entry) => {
+                        if (entry.type === "sheet") {
+                            return renderSheetItem(entry.sheet, entry.title);
+                        }
+
+                        const hasSelectedSheet = entry.sheets.some(
+                            ({ sheet }) => sheet.id === currentSheetId,
+                        );
+
+                        return (
+                            <Disclosure key={entry.title} defaultOpen={hasSelectedSheet}>
+                                <Disclosure.Button
+                                    className="sheet-group-title"
+                                    as="div"
+                                    role="button"
+                                    data-selected={hasSelectedSheet}
+                                >
+                                    <SvgAsset iconName="chevron-right"></SvgAsset>
+                                    <span>{entry.title}</span>
+                                </Disclosure.Button>
+                                <Disclosure.Panel>
+                                    {entry.sheets.map(({ sheet, title }) => renderSheetItem(sheet, title, true))}
+                                </Disclosure.Panel>
+                            </Disclosure>
+                        );
+                    })}
                 </Disclosure.Panel>
             </Disclosure>
         </div>


### PR DESCRIPTION
## Summary
- group local playlists in the sidebar when multiple playlist names share a `Group - Name` prefix pattern
- render each group as a collapsible sidebar section, with child playlists shown by their suffix name
- keep existing flat rendering for default playlists and ungrouped playlist names

## Example
Playlists named `Bili - 林俊杰`, `Bili - 周杰伦`, and `Bili - 私人致享` appear under a collapsible `Bili` group.

## Verification
- Ran ESLint dry-run on the changed sidebar files successfully.
- Tried repo-wide `tsc --noEmit`, but it is currently blocked under pnpm by unrelated existing dependency/type resolution issues: missing `react-router` types/import resolution and missing `@types/qs`.